### PR TITLE
Search user site for dist-info, not just global

### DIFF
--- a/src/zugbruecke/core/wenv.py
+++ b/src/zugbruecke/core/wenv.py
@@ -108,7 +108,7 @@ class Env(_Env):
 
         # Dist path in unix-python site-packages
         unix_dist_path = None
-        for sitepackages in site.getsitepackages():
+        for sitepackages in site.getsitepackages() + [site.getusersitepackages()]:
             if dist_name.lower() not in [item.lower() for item in os.listdir(sitepackages)]:
                 continue
             unix_dist_path = os.path.abspath(


### PR DESCRIPTION
Pip in many cases automatically installs packages to the user site-packages directory rather than the global one. `site.getsitepackages()` only returns global sites, so we also have to search the user site-packages dir (`site.getusersitepackages()`) to avoid missing dist-info errors.

Fixes an error similar to #81 